### PR TITLE
Add min/max value to cont_zmq_adapter

### DIFF
--- a/adapters/ContZMQAdapter.cpp
+++ b/adapters/ContZMQAdapter.cpp
@@ -62,6 +62,11 @@ ContZMQAdapter::tick()
             val["max"] = max;
             val["min"] = min;
             json_data.append(val);
+
+            if (val["value"] > val["max"] or val["value"] < val["min"]){
+              std::cout << "WARNING: cont_zmq_adapter received value outside of bounds" << std::endl;
+            }
+
         }
     }
    static_cast<ZMQOutPort*>(port_out)->send (writer.write(json_data));

--- a/adapters/ContZMQAdapter.cpp
+++ b/adapters/ContZMQAdapter.cpp
@@ -25,7 +25,14 @@ void ContZMQAdapter::init(int argc, char** argv)
     Adapter::init(argc, argv, "ContZMQ");
 
     // config needed for this specific adapter
-    
+    if (not setup->config("min", &min))
+    {
+      MUSIC::error ("min not specified (cont_zmq_adapter)");
+    }
+    if (not setup->config("max", &max))
+    {
+      MUSIC::error ("max not specified (cont_zmq_adapter)");
+    }
 }
 
 void
@@ -52,6 +59,8 @@ ContZMQAdapter::tick()
             Json::Value val;
             val["value"] = port_in->data[i];
             val["ts"] = ts_now;
+            val["max"] = max;
+            val["min"] = min;
             json_data.append(val);
         }
     }

--- a/adapters/ContZMQAdapter.h
+++ b/adapters/ContZMQAdapter.h
@@ -6,6 +6,7 @@
 #include <math.h>
 
 #include <music.hh>
+#include "music/error.hh"
 #include <mpi.h>
 
 #include "Adapter.h"
@@ -31,7 +32,8 @@ class ContZMQAdapter : public Adapter
     private:
         msg_types msg_type;
         Json::FastWriter writer;
-
+        double min;
+        double max;
 };
 
 #endif // CONT_ZMQ_ADAPTER_H


### PR DESCRIPTION
Allows the specification of min/max in MUSIC config file for the zmq_cont_adapter. They are not used to rescale any values, but just to fill the additional fields in the GymObservation message type. Does this make sense?