### PR TITLE
Add scale and shift factor to ThresholdAdapter

### DIFF
--- a/adapters/ThresholdAdapter.cpp
+++ b/adapters/ThresholdAdapter.cpp
@@ -20,33 +20,51 @@ ThresholdAdapter::ThresholdAdapter()
 
 void ThresholdAdapter::init(int argc, char** argv)
 {
-    threshold = DEFAULT_THRESHOLD;
-    heaviside = DEFAULT_HEAVISIDE;
-
     Adapter::init(argc, argv, "Threshold");
 
-    // config needed for this specific adapter
-    setup->config("threshold", &threshold);
-    setup->config("heaviside", &heaviside);
+    if (not setup->config("threshold", &threshold))
+    {
+        threshold = DEFAULT_THRESHOLD;
+    }
+
+    if (not setup->config("is_heaviside", &is_heaviside))
+    {
+        is_heaviside = DEFAULT_IS_HEAVISIDE;
+    }
+
+    if (not setup->config("scale", &scale))
+    {
+        scale = DEFAULT_SCALE;
+    }
+
+    if (not setup->config("shift", &shift))
+    {
+        shift = DEFAULT_SHIFT;
+    }
 }
 
 
 void
 ThresholdAdapter::tick()
 {
+    double out;
     for (int i = 0; i < port_in->data_size; ++i)
     {
         if (port_in->data[i] < threshold)
-            port_out->data[i] = 0.;
+        {
+            out = 0.;
+        }
         else
         {
-            if (heaviside == 1)
-                port_out->data[i] = 1.;
+            if (is_heaviside)
+            {
+                out = 1.;
+            }
             else
-                port_out->data[i] = port_in->data[i];
-
+            {
+                out = port_in->data[i];
+            }
         }
+        port_out->data[i] = scale * out + shift;
     }
 }
-
-

--- a/adapters/ThresholdAdapter.h
+++ b/adapters/ThresholdAdapter.h
@@ -17,7 +17,9 @@
 #include "float.h"
 
 const double DEFAULT_THRESHOLD = 0.0;
-const int DEFAULT_HEAVISIDE = 1;
+const bool DEFAULT_IS_HEAVISIDE = true;
+const double DEFAULT_SCALE = 1.0;
+const double DEFAULT_SHIFT = 0.;
 
 class ThresholdAdapter : public Adapter
 {
@@ -28,7 +30,9 @@ class ThresholdAdapter : public Adapter
 
     private:
         double threshold;
-        int heaviside;
+        bool is_heaviside;
+        double scale;
+        double shift;
 };
 
 #endif // THRESHOLD_ADAPTER_H


### PR DESCRIPTION
This PR introduces scale and shiftfactors to the threshold(linear) adapter. Also fixes loading of values from the config file: only if they are not present, the default values are used. In addition it turns the `heaviside` variable into a bool and renames it to `is_heaviside`. The former change depends on MUSIC being able to load booleans from the config file (see this PR https://github.com/INCF/MUSIC/pull/49).